### PR TITLE
Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Estimation of risk of NAION and other vision disorders from exposure to semaglut
 - Study lead forums tag: **[[Cindy X. Cai]](https://forums.ohdsi.org/u/cindyxcai)**
 - Study start date: **-**
 - Study end date: **-**
-- Protocol: **<a href="docs/Protocol.html</a>**
+- Protocol: **<a href="docs/Protocol.html">HTML Document</a>**
 - Publications: **-**
 - Results explorer: **-**
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Estimation of risk of NAION and other vision disorders from exposure to semaglut
 - Study lead forums tag: **[[Cindy X. Cai]](https://forums.ohdsi.org/u/cindyxcai)**
 - Study start date: **-**
 - Study end date: **-**
-- Protocol: **<a href="docs/Protocol.html">HTML Document</a>**
+- Protocol: **<a href="docs/protocol.html">HTML Document</a>**
 - Publications: **-**
 - Results explorer: **-**
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Estimation of risk of NAION and other vision disorders from exposure to semaglut
 - Study lead forums tag: **[[Cindy X. Cai]](https://forums.ohdsi.org/u/cindyxcai)**
 - Study start date: **-**
 - Study end date: **-**
-- Protocol: **<a href="docs/protocol.html">HTML Document</a>**
+- Protocol: **<a href="https://ohdsi-studies.github.io/SemaglutideNaion/protocol.html">HTML Document</a>**
 - Publications: **-**
 - Results explorer: **-**
 


### PR DESCRIPTION
This fixes the link to the protocol.html. For now, it links to the raw HTML.  This isn't quite what we want.

https://youtu.be/Aj4x6g7n3Mc?si=jxhnIHMrxqrX3LO5

The above section of the video shows how to enable Github pages for the repo. When that is done we can fix up the README one last time to link to a human-readable version.